### PR TITLE
Kolya182 patch 1

### DIFF
--- a/Module 2/[evaluation 00] Scalar value assignments.js
+++ b/Module 2/[evaluation 00] Scalar value assignments.js
@@ -1,0 +1,3 @@
+var answer = {
+  finalValueOfX: -7
+};

--- a/Module 2/assertArraysEqual.js
+++ b/Module 2/assertArraysEqual.js
@@ -1,13 +1,18 @@
-function assertArraysEqual(actual, expected, testName) {
-  if (JSON.stringify(actual) === JSON.stringify(expected)) {
-    return 'passed';
-  }else {
-    return 'FAILED [' + testName + '] Expected "' + expected + '", but got "' + actual + '"';
+function arrayToString(array) {
+  let convertedArrayToString = '';
+  for (let i = 0; i < array.length; i++) {
+    return convertedArrayToString += array[i];
   }
 }
 
-var expected = ['b', 'r', 'o', 'k', 'e', 'n'];
-var actual = 'broken'.split('');
+function assertArraysEqual(actual, expected, testName) {
+  if (arrayToString(actual) === arrayToString(expected)) {
+    return console.log('passed');
+  } else {
+    return console.log(`FAILED [${testName}] Expected ${expected}, but got ${actual}`);
+  }
+}
+
+let expected = ['b', 'r', 'o', 'k', 'e', 'n'];
+let actual = 'broken'.split('');
 assertArraysEqual(actual, expected, 'splits string into array of characters');
-// console output:
-// passed


### PR DESCRIPTION
* ES syntax
* Converting Arrey to String as required - “Do not use
JSON.stringify(), Array.join(), or any other "convert the array to a
string so I can compare two strings" type of technique to implement
this.”